### PR TITLE
Use unversioned automake/aclocal for configuration

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -x
-AUTOMAKE=${AUTOMAKE:-automake-1.9} ACLOCAL=${ACLOCAL:-aclocal-1.9}
+AUTOMAKE=${AUTOMAKE:-automake} ACLOCAL=${ACLOCAL:-aclocal}
 export AUTOMAKE ACLOCAL
 ${AUTORECONF:-autoreconf} -i
 find . \( -name 'run*' -o -name '*.sh' \) -a -type f | xargs chmod +x


### PR DESCRIPTION
This fixes configuration on recent Debian based distros, as they contain way newer releases of automake