### PR TITLE
Build glib interfaces when packaging for Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,3 +57,32 @@ Description: Sofia-SIP library development files
  .
  This package provides the headers and libraries needed to build
  applications against the Sofia-SIP library.
+
+Package: libsofia-sip-ua-glib3
+Architecture: any
+Section: libs
+Depends: libsofia-sip-ua0 (= ${binary:Version}), ${shlibs:Depends}
+Suggests: sofia-sip-doc
+Description: Sofia-SIP library glib/gobject interfaces runtime
+ Sofia-SIP is an open-source SIP User-Agent library, compliant
+ with the IETF RFC3261 specification. It can be used as
+ a building block for SIP client software for uses such as VoIP,
+ IM, and many other real-time and person-to-person communication
+ services.
+ .
+ This package provides glib/object interfaces to the Sofia-SIP library.
+
+Package: libsofia-sip-ua-glib-dev
+Architecture: any
+Section: libdevel
+Depends: libsofia-sip-ua-glib3 (= ${binary:Version}), libsofia-sip-ua-dev, libglib2.0-dev
+Suggests: sofia-sip-doc
+Description: Sofia-SIP library glib/gobject interface development files
+ Sofia-SIP is an open-source SIP User-Agent library, compliant
+ with the IETF RFC3261 specification. It can be used as
+ a building block for SIP client software for uses such as VoIP,
+ IM, and many other real-time and person-to-person communication
+ services.
+ .
+ This package provides the headers and libraries needed to build
+ applications against the glib/object interfaces of Sofia-SIP library.

--- a/debian/libsofia-sip-ua-glib-dev.install
+++ b/debian/libsofia-sip-ua-glib-dev.install
@@ -1,2 +1,3 @@
 usr/lib/libsofia-sip-ua-glib.a
 usr/lib/libsofia-sip-ua-glib.so
+usr/lib/pkgconfig/sofia-sip-ua-glib.pc

--- a/debian/libsofia-sip-ua-glib-dev.install
+++ b/debian/libsofia-sip-ua-glib-dev.install
@@ -1,0 +1,2 @@
+usr/lib/libsofia-sip-ua-glib.a
+usr/lib/libsofia-sip-ua-glib.so

--- a/debian/libsofia-sip-ua-glib3.install
+++ b/debian/libsofia-sip-ua-glib3.install
@@ -1,0 +1,1 @@
+usr/lib/libsofia-sip-ua-glib.so.*

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,6 @@ override_dh_auto_configure:
 	./configure \
 	  --prefix=/usr \
 	  --with-pic \
-	  --with-glib=no \
 	  --disable-stun
 
 override_dh_auto_test:


### PR DESCRIPTION
This commit adds debian packaging metadata to build the glib interface
packages along with libsofia-sip-ua. The package descriptions are
minimal and based off the original upstream debian control file.

I tested building and installing the glib bindings on debian10, and
was able to succesully compile and run the osmo-stp-connector with
these packages.
