### PR TITLE
[sresolv] account for Refused DNS rcode

### DIFF
--- a/libsofia-sip-ua/sresolv/sres.c
+++ b/libsofia-sip-ua/sresolv/sres.c
@@ -3664,7 +3664,8 @@ sres_decode_msg(sres_resolver_t *res,
 
   if (err == SRES_RECORD_ERR ||
       err == SRES_NAME_ERR ||
-      err == SRES_UNIMPL_ERR)
+      err == SRES_UNIMPL_ERR ||
+      err == SRES_AUTH_ERR)
     errorcount = 1;
 
   total = errorcount + m->m_ancount + m->m_nscount + m->m_arcount;


### PR DESCRIPTION
Acknowledges refused queries as proper errors, per RFC 1035 (section 4.1.1 rcode 5).