### PR TITLE
Fix Curves/Groups offering for TLS clients

### DIFF
--- a/libsofia-sip-ua/tport/tport_tls.c
+++ b/libsofia-sip-ua/tport/tport_tls.c
@@ -430,7 +430,9 @@ int tls_init_context(tls_t *tls, tls_issues_t const *ti)
   SSL_CTX_set_verify_depth(tls->ctx, ti->verify_depth);
   SSL_CTX_set_verify(tls->ctx, verify, tls_verify_cb);
 #ifndef OPENSSL_NO_EC
-  if (tls_init_ecdh_curve(tls) == 0) {
+  if (tls->accept == 0) {
+    SU_DEBUG_3(("%s\n", "tls: initialized ECDH"));
+  } else if (tls_init_ecdh_curve(tls) == 0) {
     SU_DEBUG_3(("%s\n", "tls: initialized ECDH"));
   } else {
     SU_DEBUG_3(("%s\n", "tls: failed to initialize ECDH"));


### PR DESCRIPTION
Six years ago, commit e83a2e5 enabled ECDHE for the TLS server by hard-coding P-256. As a side-effect it also limited the offered curves/groups of TLS clients to P-256. This limitation was never required, because a TLS client based on OpenSSL offered all enabled curves/groups automatically. The change here makes sure that special handling is done for TLS servers only. Not to confuse consumers of log files, the behavior on the debug output is not changed.