### PR TITLE
Add new API tport_is_recoverable() and don't try to recover WS and WSS.

### DIFF
--- a/libsofia-sip-ua/tport/sofia-sip/tport.h
+++ b/libsofia-sip-ua/tport/sofia-sip/tport.h
@@ -234,6 +234,9 @@ TPORT_DLL int tport_release(tport_t *self, int pendd,
 			    msg_t *msg, msg_t *reply, tp_client_t *client,
 			    int still_pending);
 
+/** Return true if transport is recoverable. */
+TPORT_DLL int tport_is_recoverable(tport_t const *self);
+
 /** Return true if transport is master. */
 TPORT_DLL int tport_is_master(tport_t const *self);
 

--- a/libsofia-sip-ua/tport/tport.c
+++ b/libsofia-sip-ua/tport/tport.c
@@ -3379,6 +3379,11 @@ tport_t *tport_tsend(tport_t *self,
     }
     resolved = 1;
 
+    if (!tport_is_recoverable(self)) {
+      SU_DEBUG_9(("tport_tsend(%p) transport is not recoverable!\n", (void *)self));
+      return self;
+    }
+
     self = tport_by_addrinfo(primary, msg_addrinfo(msg), tpn);
 
     if (!self)
@@ -3388,11 +3393,6 @@ tport_t *tport_tsend(tport_t *self,
   if (tport_is_primary(self)) {
     /* If primary, resolve the destination address, store it in the msg */
     if (!resolved && tport_resolve(self, msg, tpn) < 0) {
-      return NULL;
-    }
-
-    if (!tport_is_recoverable(self)) {
-      SU_DEBUG_9(("tport_tsend(%p) transport is not recoverable!\n", (void *)self));
       return NULL;
     }
 

--- a/libsofia-sip-ua/tport/tport.c
+++ b/libsofia-sip-ua/tport/tport.c
@@ -3258,6 +3258,15 @@ int tport_recv_error_report(tport_t *self)
   return -1;
 }
 
+/** Return true if transport is recoverable. */
+int tport_is_recoverable(tport_t const *self)
+{
+  return
+    self &&
+    strcmp("ws", self->tp_protoname) &&
+    strcmp("wss", self->tp_protoname);
+}
+
 /** Send a message.
  *
  * The function tport_tsend() sends a message using the transport @a self.
@@ -3379,6 +3388,11 @@ tport_t *tport_tsend(tport_t *self,
   if (tport_is_primary(self)) {
     /* If primary, resolve the destination address, store it in the msg */
     if (!resolved && tport_resolve(self, msg, tpn) < 0) {
+      return NULL;
+    }
+
+    if (!tport_is_recoverable(self)) {
+      SU_DEBUG_9(("tport_tsend(%p) transport is not recoverable!\n", (void *)self));
       return NULL;
     }
 


### PR DESCRIPTION
Following https://github.com/signalwire/freeswitch/pull/312