### PR TITLE
Fix memory leaks when nua start fails by moving nua cleanups from nua_destroy() to nua_stack_deinit()

### DIFF
--- a/libsofia-sip-ua/nua/nua.c
+++ b/libsofia-sip-ua/nua/nua.c
@@ -228,9 +228,6 @@ void nua_destroy(nua_t *nua)
     nua->nua_callback = NULL;
 
     su_clone_wait(nua->nua_api_root, nua->nua_clone);
-#if HAVE_SMIME		/* Start NRC Boston */
-    sm_destroy(nua->sm);
-#endif			/* End NRC Boston */
 
 	nua_unref(nua);
   }

--- a/libsofia-sip-ua/nua/nua.c
+++ b/libsofia-sip-ua/nua/nua.c
@@ -171,7 +171,8 @@ nua_t *nua_create(su_root_t *root,
       nua->nua_magic = magic;
     }
     else {
-      su_home_unref(nua->nua_home);
+      nua->nua_shutdown_final = 1;
+      nua_destroy(nua);
       nua = NULL;
     }
 #endif

--- a/libsofia-sip-ua/nua/nua.c
+++ b/libsofia-sip-ua/nua/nua.c
@@ -171,8 +171,7 @@ nua_t *nua_create(su_root_t *root,
       nua->nua_magic = magic;
     }
     else {
-      nua->nua_shutdown_final = 1;
-      nua_destroy(nua);
+      su_home_unref(nua->nua_home);
       nua = NULL;
     }
 #endif
@@ -216,7 +215,6 @@ void nua_shutdown(nua_t *nua)
  */
 void nua_destroy(nua_t *nua)
 {
-  nua_handle_t *nh, *nh_next;
   enter;
 
   if (nua) {
@@ -229,30 +227,10 @@ void nua_destroy(nua_t *nua)
 
     nua->nua_callback = NULL;
 
-    su_task_deinit(nua->nua_server);
-    su_task_deinit(nua->nua_client);
-
     su_clone_wait(nua->nua_api_root, nua->nua_clone);
 #if HAVE_SMIME		/* Start NRC Boston */
     sm_destroy(nua->sm);
 #endif			/* End NRC Boston */
-
-    /* Cleanup remaining nua handles as they are su_home_new'ed and not su_home_cloned (do not belong to the nua's home)
-       See nh_create_handle().
-    */
-    for (nh = nua->nua_handles; nh; nh = nh_next) {
-      su_home_t *nh_home = (su_home_t *)nh;
-      nh_next = nh->nh_next;
-
-      /* at least one handle will be found here and it is nua default handle
-         which is su_home_cloned (see nua_stack_init()) and therefore does not actually require to be unrefed
-         but it is safe to do that anyways just for sure
-      */
-      SU_DEBUG_9(("nua(%p): found handle with refcount = "MOD_ZU". Destroying.\n", (void *)nh, su_home_refcount(nh_home)));
-
-      /* nua is about to die so we don't remove nh from nua, just unref nh */
-      while(!su_home_unref(nh_home));
-    }
 
 	nua_unref(nua);
   }

--- a/libsofia-sip-ua/nua/nua_stack.c
+++ b/libsofia-sip-ua/nua/nua_stack.c
@@ -237,6 +237,11 @@ void nua_stack_deinit(su_root_t *root, nua_t *nua)
       SU_DEBUG_9(("nua(%p): found handle with refcount = "MOD_ZU". Destroying.\n", (void *)nh, su_home_refcount(nh_home)));
       while(!su_home_unref(nh_home));
     }
+
+#if HAVE_SMIME		/* Start NRC Boston */
+    sm_destroy(nua->sm);
+#endif			/* End NRC Boston */}
+
   }
 }
 

--- a/libsofia-sip-ua/nua/nua_stack.c
+++ b/libsofia-sip-ua/nua/nua_stack.c
@@ -209,8 +209,16 @@ int nua_stack_init(su_root_t *root, nua_t *nua)
 
 void nua_stack_deinit(su_root_t *root, nua_t *nua)
 {
-  enter;
+  nua_handle_t *nh, *nh_next;
 
+  enter;
+  for (nh = nua->nua_handles; nh; nh = nh_next) {
+    nh_next = nh->nh_next;
+
+    if (nh->nh_soa) {
+      soa_destroy(nh->nh_soa), nh->nh_soa = NULL;
+    }
+  }
   su_timer_destroy(nua->nua_timer), nua->nua_timer = NULL;
   nta_agent_destroy(nua->nua_nta), nua->nua_nta = NULL;
 }

--- a/libsofia-sip-ua/nua/nua_stack.c
+++ b/libsofia-sip-ua/nua/nua_stack.c
@@ -212,15 +212,32 @@ void nua_stack_deinit(su_root_t *root, nua_t *nua)
   nua_handle_t *nh, *nh_next;
 
   enter;
+
+  su_task_deinit(nua->nua_server);
+  su_task_deinit(nua->nua_client);
+
+  su_timer_destroy(nua->nua_timer), nua->nua_timer = NULL;
+  nta_agent_destroy(nua->nua_nta), nua->nua_nta = NULL;
+
   for (nh = nua->nua_handles; nh; nh = nh_next) {
     nh_next = nh->nh_next;
 
     if (nh->nh_soa) {
       soa_destroy(nh->nh_soa), nh->nh_soa = NULL;
     }
+
+    /* Cleanup remaining nua handles as they are su_home_new'ed and not su_home_cloned (do not belong to the nua's home)
+       See nh_create_handle().
+       At least one handle will be found here and it is nua default handle
+       which is su_home_cloned (see nua_stack_init()) and therefore does not actually require to be unrefed.
+       Nua is about to die so we don't remove nh from nua, just unref nh */
+    if (nh != nua->nua_handles) {
+      su_home_t *nh_home = (su_home_t *)nh;
+
+      SU_DEBUG_9(("nua(%p): found handle with refcount = "MOD_ZU". Destroying.\n", (void *)nh, su_home_refcount(nh_home)));
+      while(!su_home_unref(nh_home));
+    }
   }
-  su_timer_destroy(nua->nua_timer), nua->nua_timer = NULL;
-  nta_agent_destroy(nua->nua_nta), nua->nua_nta = NULL;
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
the port leak is producing by https://github.com/freeswitch/sofia-sip/blob/2a2c3ac95b2eb553df4bdf409d10ce71f4d6c0d5/libsofia-sip-ua/nua/nua.c#L156

all I need to do is call https://github.com/freeswitch/sofia-sip/blob/2a2c3ac95b2eb553df4bdf409d10ce71f4d6c0d5/libsofia-sip-ua/nua/nua.c#L231