### PR TITLE
Repair XML by removing double closing tag

### DIFF
--- a/win32/libsofia-sip-ua-static/libsofia_sip_ua_static.vcproj
+++ b/win32/libsofia-sip-ua-static/libsofia_sip_ua_static.vcproj
@@ -4273,7 +4273,6 @@
 					RelativePath="..\..\libsofia-sip-ua\sresolv\sofia-sip\sresolv.h"
 					>
 				</File>
-				</File>
 				<File
 					RelativePath="..\..\libsofia-sip-ua\sresolv\sofia-sip\sres_sip.h"
 					>


### PR DESCRIPTION
Double closing tag removed:  "				</File>"
Because it caused invalid XML syntax error while migrating with VS 2017.

"The following XML parser error has occurred: File: C:\sofia-sip-1.13.3\win32\libsofia-sip-ua-static\libsofia_sip_ua_static.vcproj Line: 4276 Column: 11 Error message: The name contained in the end tag of the element must match the element type in the start tag. The file "C:\sofia-sip-1.13.3\win32\libsofia-sip-ua-static\libsofia_sip_ua_static.vcproj" could not be loaded."