### PR TITLE
Initialize done_once to 0 to avoid unnecesary cleanup

### DIFF
--- a/libsofia-sip-ua/su/su_uniqueid.c
+++ b/libsofia-sip-ua/su/su_uniqueid.c
@@ -90,12 +90,15 @@ union state {
 #endif
 
 static pthread_once_t once = PTHREAD_ONCE_INIT;
-static int done_once = 1;
+static int done_once = 0;
 static pthread_key_t state_key;
 
 static void
 init_once(void)
 {
+  if (done_once)
+    return;
+
   pthread_key_create(&state_key, free);
 #if HAVE_DEV_URANDOM
   urandom = fopen("/dev/urandom", "rb");


### PR DESCRIPTION
This patch makes sure that we're not calling `pthread_key_delete ()` on
a key we never created in the first place.

Fixes #58

I've done some testing that it actually fixes my issue and additionally doesn't break other things (by compiling and running test programs - `make check` did pass most tests, but then i got an (unrelated) error that i don't have a "check.h")