### PR TITLE
Parse i-line at media level in SDP record

### DIFF
--- a/libsofia-sip-ua/sdp/sdp_parse.c
+++ b/libsofia-sip-ua/sdp/sdp_parse.c
@@ -1770,6 +1770,10 @@ static void parse_descs(sdp_parser_t *p,
       bandwidths = &(*bandwidths)->b_next;
       break;
 
+    case 'i': 
+      parse_information(p, rest, &m->m_information);
+      break;
+     
     case 'k':
       parse_key(p, rest, &m->m_key);
       break;


### PR DESCRIPTION
Parse i-line at media level in SDP record. 
An i-line at media level in a SDP record is ignored without this update.