### PR TITLE
WSS: clear openssl errors to prevent error contagion

### DIFF
--- a/libsofia-sip-ua/tport/ws.c
+++ b/libsofia-sip-ua/tport/ws.c
@@ -767,10 +767,8 @@ void ws_destroy(wsh_t *wsh)
 		do {
 			if (code == -1) {
 				int ssl_err = SSL_get_error(wsh->ssl, code);
-				if (ssl_err != SSL_ERROR_WANT_READ) {
-					wss_error(wsh, ssl_err, "ws_destroy: SSL_shutdown");
-					break;
-				}
+				wss_error(wsh, ssl_err, "ws_destroy: SSL_shutdown");
+				break;
 			}
 			code = SSL_shutdown(wsh->ssl);
 		// } while (code == -1 && SSL_get_error(wsh->ssl, code) == SSL_ERROR_WANT_READ);


### PR DESCRIPTION
I use self-signed certificate on the server.
A wss client trusts this certificate temporarily, after a long time, it rejects the server with an error "sslv3 alert certificate unknown". This error is stored in the wss openssl error queue, but nobody handles it.
If another wss client makes a call, function ws_raw_read will fail (REGISTER works but INVITE doesn't) and the server will reset this client's wss connection.
In the most extreme cases (that's exactly what I encountered), the old wss client tries to reconnect to the server and keeps replying with errors, the server will reset all wss connections that want to make calls (send INVITE), and the system will become unavailable.

There is just another ws.c in mod_verto. If this pull request is approved, I will port it to there too.