### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -21,6 +21,9 @@ Sofia-SIP uses the GNU autotools, so building procedure
 is the usual:
 
 sh> sh autogen.sh (if building from darcs)
+or
+sh> sh botstrap.sh
+
 sh> ./configure
 sh> make
 sh> make install


### PR DESCRIPTION
Launching autogen.sh on debian creates errors, launching bootstrap.sh instead of autogen.sh allows the library to compile correctly