### PR TITLE
Fix ECDH support for OpenSSL < 1.1.0

### DIFF
--- a/libsofia-sip-ua/tport/tport_tls.c
+++ b/libsofia-sip-ua/tport/tport_tls.c
@@ -434,6 +434,13 @@ int tls_init_context(tls_t *tls, tls_issues_t const *ti)
   SSL_CTX_set_verify_depth(tls->ctx, ti->verify_depth);
   SSL_CTX_set_verify(tls->ctx, verify, tls_verify_cb);
 #ifndef OPENSSL_NO_EC
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  if (tls_init_ecdh_curve(tls) == 0) {
+    SU_DEBUG_3(("%s\n", "tls: initialized ECDH"));
+  } else {
+    SU_DEBUG_3(("%s\n", "tls: failed to initialize ECDH"));
+  }
+#else
   if (tls->accept == 0) {
     SU_DEBUG_3(("%s\n", "tls: initialized ECDH"));
   } else if (tls_init_ecdh_curve(tls) == 0) {
@@ -441,6 +448,7 @@ int tls_init_context(tls_t *tls, tls_issues_t const *ti)
   } else {
     SU_DEBUG_3(("%s\n", "tls: failed to initialize ECDH"));
   }
+#endif
 #endif
   if (!SSL_CTX_set_cipher_list(tls->ctx, ti->ciphers)) {
     SU_DEBUG_1(("%s: error setting cipher list\n", "tls_init_context"));


### PR DESCRIPTION
We noticed commit c43905b breaks ECDH(e) usage in combination with OpenSSL 1.0.2 and TLS-Server.

It can be reproduced with a simple openssl s_client command:

	openssl s_client -connect 127.0.0.1:5061 -tls1_2 -cipher 'ECDHE-RSA-AES256-GCM-SHA384'

which results in a handshake abort and the following log output:

	tport.c:2770 tport_wakeup_pri() tport_wakeup_pri(0x7fbae8005190): events IN
	tport.c:862 tport_alloc_secondary() tport_alloc_secondary(0x7fbae8005190): new secondary tport 0x7fbae8001420
	tport_type_tcp.c:203 tport_tcp_init_secondary() tport_tcp_init_secondary(0x7fbae8001420): Setting TCP_KEEPIDLE to 30
	tport_type_tcp.c:209 tport_tcp_init_secondary() tport_tcp_init_secondary(0x7fbae8001420): Setting TCP_KEEPINTVL to 30
	tport_type_tls.c:613 tport_tls_accept() tport_tls_accept(0x7fbae8001420): new connection from tls/127.0.0.1:50388/sips
	tport_tls.c:972 tls_connect() tls_connect(0x7fbae8001420): events NEGOTIATING
	tport_tls.c:157 tls_log_errors() TLS setup failed: 00000001:(null):(null):(null)
	tport_tls.c:157 tls_log_errors() TLS setup failed: 1408a0c1:SSL routines:ssl3_get_client_hello:no shared cipher
	tport.c:2098 tport_close() tport_close(0x7fbae8001420): tls/127.0.0.1:50388/sips
	tport_tls.c:157 tls_log_errors() tls_free: 140e0197:SSL routines:SSL_shutdown:shutdown while in init
	tport.c:2273 tport_set_secondary_timer() tport(0x7fbae8001420): set timer at 0 ms because zap


During startup (tls_init_context) the following line is logged:

	tport_tls.c:438 tls_init_context() tls: initialized ECDH

which can be traced to the following lines in `tport_tls.c`:

	if (tls->accept == 0) {
	    SU_DEBUG_3(("%s\n", "tls: initialized ECDH"));
	}

Since OpensSSL 1.1.0 ECDH is turned on automatically, so set_ecdh_auto() has not to be called anymore.
To get back the compatiblity for OpenSSL 1.0.2 I suggest to init the ecdh during the tls_init, as we did before c43905b, in case that OpenSSL < 1.1.0 is used.
This will support RHEL 7 based libsofia builds again, which uses OpenSSL 1.0.2 and therefore are currently broken.