### PR TITLE
Ignore provisional responses only if call is not answered yet #117

### DIFF
--- a/libsofia-sip-ua/nua/nua_session.c
+++ b/libsofia-sip-ua/nua/nua_session.c
@@ -948,8 +948,8 @@ static int nua_session_client_response(nua_client_request_t *cr,
   else if (!session_get_description(sip, &sdp, &len))
     /* No SDP */;
   else if (cr->cr_answer_recv) {
-    if (cr->cr_answer_recv > status) {
-      LOG3("status is older than previous answer, ignoring");
+    if (status < 200 && cr->cr_answer_recv >= 200) {
+      LOG3("call already answered, ignoring provisional response");
       sdp = NULL;
       return 0;
     } else {


### PR DESCRIPTION
The original intent of FS-11452 was to quickly escape provisional responses received after a 200OK (probably out of order packets).

Instead of pretending that SIP statuses are always increasing, check status codes and fast ignore 1XX only if call status is alreay 200