### PR TITLE
https://github.com/signalwire/freeswitch/issues/1014 fix to enabled F…

### DIFF
--- a/libsofia-sip-ua/nua/nua_session.c
+++ b/libsofia-sip-ua/nua/nua_session.c
@@ -2480,6 +2480,9 @@ int nua_invite_server_is_100rel(nua_server_request_t *sr, tagi_t const *tags)
     return 0;
   if (sr->sr_status == 183)
     return 1;
+  /*Also include 180 when 100rel is required */
+  if (sr->sr_status == 180)
+    return 1;
 
   if (NH_PGET(nh, early_media) && !NH_PGET(nh, only183_100rel))
     return 1;


### PR DESCRIPTION
Enable FreeSWITCH to send PRACK upon receiving reliable 180, or to send 180 Ringing reliably (with Require: 100rel and a RSeq header)
https://github.com/signalwire/freeswitch/issues/1014 