### PR TITLE
FS-11275 180/183 after 200 causes call to stall and never recovers

### DIFF
--- a/libsofia-sip-ua/nta/nta.c
+++ b/libsofia-sip-ua/nta/nta.c
@@ -9491,6 +9491,9 @@ int outgoing_recv(nta_outgoing_t *_orq,
     outgoing_reset_timer(original); /* Retransmission */
 
     if (status < 200) {
+      if (original->orq_queue == sa->sa_out.inv_completed) {
+	return outgoing_duplicate(orq, msg, sip);
+      }
       if (original->orq_status < 200)
 	original->orq_status = status;
       if (orq->orq_status < 200)


### PR DESCRIPTION
Hi,

This PR will fix the issue https://freeswitch.org/jira/browse/FS-11275, the root cause is once the 180/183 message behind the 200 message (network jetter), sofia will to waiting the ACK for 180/183, until timeout.
The solution is, ignore the 180/183 if current state already is completed.

Please help review and merge the change.

Thanks
