### PR TITLE
fix WSS close

### DIFF
--- a/libsofia-sip-ua/tport/tport_type_ws.c
+++ b/libsofia-sip-ua/tport/tport_type_ws.c
@@ -92,8 +92,8 @@ tport_vtable_t const tport_ws_vtable =
   /* vtp_connect             */ NULL,
   /* vtp_secondary_size      */ sizeof (tport_ws_t),
   /* vtp_init_secondary      */ tport_ws_init_secondary,
-  /* tp_deinit_secondary    */ tport_ws_deinit_secondary,
-  /* vtp_shutdown            */ NULL,
+  /* tp_deinit_secondary     */ tport_ws_deinit_secondary,
+  /* vtp_shutdown            */ tport_ws_shutdown,
   /* vtp_set_events          */ NULL,
   /* vtp_wakeup              */ NULL,
   /* vtp_recv                */ tport_recv_stream_ws,
@@ -118,7 +118,7 @@ tport_vtable_t const tport_ws_client_vtable =
   /* vtp_secondary_size      */ sizeof (tport_ws_t),
   /* vtp_init_secondary      */ tport_ws_init_secondary,
   /* vtp_deinit_secondary    */ NULL,
-  /* vtp_shutdown            */ NULL,
+  /* vtp_shutdown            */ tport_ws_shutdown,
   /* vtp_set_events          */ NULL,
   /* vtp_wakeup              */ NULL,
   /* vtp_recv                */ tport_recv_stream_ws,
@@ -143,7 +143,7 @@ tport_vtable_t const tport_wss_vtable =
   /* vtp_secondary_size      */ sizeof (tport_ws_t),
   /* vtp_init_secondary      */ tport_ws_init_secondary,
   /* vtp_deinit_secondary    */ tport_ws_deinit_secondary,
-  /* vtp_shutdown            */ NULL,
+  /* vtp_shutdown            */ tport_ws_shutdown,
   /* vtp_set_events          */ NULL,
   /* vtp_wakeup              */ NULL,
   /* vtp_recv                */ tport_recv_stream_ws,
@@ -168,7 +168,7 @@ tport_vtable_t const tport_wss_client_vtable =
   /* vtp_secondary_size      */ sizeof (tport_ws_t),
   /* vtp_init_secondary      */ tport_ws_init_secondary,
   /* vtp_deinit_secondary    */ NULL,
-  /* vtp_shutdown            */ NULL,
+  /* vtp_shutdown            */ tport_ws_shutdown,
   /* vtp_set_events          */ NULL,
   /* vtp_wakeup              */ NULL,
   /* vtp_recv                */ tport_recv_stream_ws,
@@ -531,6 +531,13 @@ static void tport_ws_deinit_secondary(tport_t *self)
 		ws_destroy(&wstp->ws);
 		wstp->ws_initialized = -1;
 	}
+}
+
+void tport_ws_shutdown(tport_t *self, int how)
+{
+	tport_ws_t *wstp = (tport_ws_t *)self;
+
+	ws_shutdown(&wstp->ws, how);
 }
 
 static int tport_ws_setsndbuf(int socket, int atleast)

--- a/libsofia-sip-ua/tport/tport_ws.h
+++ b/libsofia-sip-ua/tport/tport_ws.h
@@ -89,6 +89,7 @@ int tport_ws_init_client(tport_primary_t *,
  			 char const **return_culprit);
 int tport_ws_init_secondary(tport_t *self, int socket, int accepted,
 			     char const **return_reason);
+void tport_ws_shutdown(tport_t *self, int how);
 
 int tport_ws_next_timer(tport_t *self, su_time_t *, char const **);
 void tport_ws_timer(tport_t *self, su_time_t);

--- a/libsofia-sip-ua/tport/ws.c
+++ b/libsofia-sip-ua/tport/ws.c
@@ -755,6 +755,34 @@ int ws_init(wsh_t *wsh, ws_socket_t sock, SSL_CTX *ssl_ctx, int close_sock, int 
 	return 0;
 }
 
+void ws_shutdown(wsh_t *wsh, int how) 
+{
+	if (!wsh) {
+		return;
+	}
+
+	if (wsh->down) { 
+		return;
+	}
+
+	if (wsh->ssl) {
+		int code = 0;
+		do {
+			if (code == -1) {
+				int ssl_err = SSL_get_error(wsh->ssl, code);
+				wss_error(wsh, ssl_err, "ws_shutdown: SSL_shutdown");
+				break;
+			}
+			code = SSL_shutdown(wsh->ssl);
+		} while (code == -1);
+
+		SSL_free(wsh->ssl);
+		wsh->ssl = NULL;
+	}
+
+	shutdown(wsh->sock, how);
+}
+
 void ws_destroy(wsh_t *wsh)
 {
 

--- a/libsofia-sip-ua/tport/ws.h
+++ b/libsofia-sip-ua/tport/ws.h
@@ -130,6 +130,7 @@ ssize_t ws_write_frame(wsh_t *wsh, ws_opcode_t oc, void *data, size_t bytes);
 int ws_init(wsh_t *wsh, ws_socket_t sock, SSL_CTX *ssl_ctx, int close_sock, int block, int stay_open);
 ssize_t ws_close(wsh_t *wsh, int16_t reason);
 void ws_destroy(wsh_t *wsh);
+void ws_shutdown(wsh_t *wsh, int how);
 void init_ssl(void);
 void deinit_ssl(void);
 int xp_errno(void);


### PR DESCRIPTION
Closing a WSS connection breaks communication on a reused socket handle.
SSL_shutdown() should be called before closing socket to avoid TLS close notify to be send on a reused socket.
