### PR TITLE
Fault tolerant repair

### DIFF
--- a/libsofia-sip-ua/nua/nua_server.c
+++ b/libsofia-sip-ua/nua/nua_server.c
@@ -415,6 +415,7 @@ nua_stack_respond(nua_t *nua, nua_handle_t *nh,
   nua_server_request_t *sr;
   tagi_t const *t;
   msg_t const *request = NULL;
+  int prack_pending = 0;
 
   t = tl_find_last(tags, nutag_with);
 
@@ -425,8 +426,17 @@ nua_stack_respond(nua_t *nua, nua_handle_t *nh,
     if (request && sr->sr_request.msg == request)
       break;
     /* nua_respond() to INVITE can be used without NUTAG_WITH() */
-    if (!t && sr->sr_method == sip_method_invite)
+    if (!t && sr->sr_method == sip_method_invite) {
+      if (prack_pending) {
+        nua_stack_event(nua, nh, NULL, nua_i_error,
+			500, "Server Internal Error", NULL);
+      }
       break;
+    }
+    else if (!t && sr->sr_method == sip_method_prack) {
+      prack_pending = 1;
+      return;
+    }
   }
 
   if (sr == NULL) {


### PR DESCRIPTION
Cause i try to use NUTAG_APPL_METHOD("PRACK") to handle PRACK and 200OK for PRACK by application layer.
But sometime the network transmission is not satisfactory, the network problems caused sofia received 200ok for invite before receiving 200ok for prack.

And after handle 200OK for invite the nua_server_request_destroy function remove 200OK for INVITE from ds_sr list, then call su_free to release INVITE server request([nua_server.c:336](https://github.com/freeswitch/sofia-sip/blob/master/libsofia-sip-ua/nua/nua_server.c#L336)) and the pointor sr0 will release and use to other new address, a new pointer will point to the freed memory,and maybe change the "sr_signal" pointer variable.

The "dr_sr" list only contains a request for prack, until 200 OK for prack arrives and processing at nua_prack_server_report, it will check the sr->sr_irq->irq_magic->sr_signal([nua_session.c:2986](https://github.com/freeswitch/sofia-sip/blob/master/libsofia-sip-ua/nua/nua_session.c#L2986)), and i know sr->sr_irq is equal to the previously released invite request sr, but at this time sofia don't know the sr->sr_irq is a released memory, maybe sr_signal is any number but not null ! It will call sr_signal at ([nua_session.c:2989](https://github.com/freeswitch/sofia-sip/blob/master/libsofia-sip-ua/nua/nua_session.c#L2989)), the illegal memory address accessed.lead to all process to core dump.

I know this is a wrong order. 200ok for invite was received before 200ok for prack.So this is why i call it a fault tolerant repair.
I think we should check whether there are unprocessed requests before processing 200ok for invite. If there are, send 500 error.