### PR TITLE
sdp_parse.c: allow msgsize = -1 in sdp_parse() arguments

### DIFF
--- a/libsofia-sip-ua/sdp/sdp_parse.c
+++ b/libsofia-sip-ua/sdp/sdp_parse.c
@@ -110,8 +110,12 @@ static int parsing_error(sdp_parser_t *p, char const *fmt, ...);
 /** Parse an SDP message.
  *
  * The function sdp_parse() parses an SDP message @a msg of size @a
- * msgsize. Parsing is done according to the given @a flags. The SDP message
- * may not contain a NUL.
+ * msgsize. If msgsize is -1, the size of message is calculated using
+ * strlen().
+ *
+ * Parsing is done according to the given @a flags.
+ *
+ * The SDP message may not contain a NUL.
  *
  * The parsing result is stored to an #sdp_session_t structure.
  *
@@ -147,7 +151,7 @@ sdp_parse(su_home_t *home, char const msg[], issize_t msgsize, int flags)
   char *b;
   size_t len;
 
-  if (msgsize == -1 || msg == NULL) {
+  if (msg == NULL) {
     p = su_home_clone(home, sizeof(*p));
     if (p)
       parsing_error(p, "invalid input message");
@@ -156,7 +160,7 @@ sdp_parse(su_home_t *home, char const msg[], issize_t msgsize, int flags)
     return p;
   }
 
-  if (msgsize == -1 && msg)
+  if (msgsize == -1)
     len = strlen(msg);
   else
     len = msgsize;


### PR DESCRIPTION
I was wondering why `sdp_parse()` with `msgsize = -1` kept failing when building sofia-sip from source but not when using the debian package. Then I found that debian applies this patch https://salsa.debian.org/pkg-voip-team/sofia-sip/-/commit/4df0ebb90a381e9b892b53aa5cfcac4a5fbdcabc

CC: @fortysixandtwo