### PR TITLE
Fix check of poll result in sresolv

### DIFF
--- a/libsofia-sip-ua/sresolv/sres_blocking.c
+++ b/libsofia-sip-ua/sresolv/sres_blocking.c
@@ -171,9 +171,9 @@ int sres_blocking_complete(sres_blocking_context_t *c)
       sres_resolver_timer(c->resolver, -1);
     }
     else for (i = 0; i < c->block->n_sockets; i++) {
-      if (c->block->fds[i].revents | POLLERR)
+      if (c->block->fds[i].revents & POLLERR)
 	sres_resolver_error(c->resolver, c->block->fds[i].fd);
-      if (c->block->fds[i].revents | POLLIN)
+      if (c->block->fds[i].revents & POLLIN)
 	sres_resolver_receive(c->resolver, c->block->fds[i].fd);
     }
 #elif HAVE_SELECT


### PR DESCRIPTION
The resolver uses this code when poll is used, e.g. on macos.
This PR fixes a bug when checking the result of the poll function on each socket.