### PR TITLE
Transport interface: force socket binding to network interface

### DIFF
--- a/libsofia-sip-ua/tport/sofia-sip/tport_tag.h
+++ b/libsofia-sip-ua/tport/sofia-sip/tport_tag.h
@@ -148,6 +148,14 @@ TPORT_DLL extern tag_typedef_t tptag_socket_keepalive;
 TPORT_DLL extern tag_typedef_t tptag_socket_keepalive_ref;
 #define TPTAG_SOCKET_KEEPALIVE_REF(x) tptag_socket_keepalive_ref, tag_uint_vr(&(x))
 
+#if defined (__linux__)
+TPORT_DLL extern tag_typedef_t tptag_socket_bind_ifc;
+#define TPTAG_SOCKET_BIND_IFC(x) tptag_socket_bind_ifc, tag_bool_v((x))
+
+TPORT_DLL extern tag_typedef_t tptag_socket_bind_ifc_ref;
+#define TPTAG_SOCKET_BIND_IFC_REF(x) tptag_socket_bind_ifc_ref, tag_bool_vr(&(x))
+#endif
+
 TPORT_DLL extern tag_typedef_t tptag_keepalive;
 #define TPTAG_KEEPALIVE(x) tptag_keepalive, tag_uint_v((x))
 

--- a/libsofia-sip-ua/tport/tport_internal.h
+++ b/libsofia-sip-ua/tport/tport_internal.h
@@ -123,6 +123,9 @@ typedef struct {
   unsigned tpp_sdwn_error:1;	/**< If true, shutdown is error. */
   unsigned tpp_stun_server:1;	/**< If true, use stun server */
   unsigned tpp_pong2ping:1;	/**< If true, respond with pong to ping */
+  #if defined (__linux__)
+  unsigned tpp_socket_bind_ifc:1; /**< If true, force socket bind to the interface */
+  #endif
 
   unsigned :0;
 
@@ -440,10 +443,10 @@ void tport_base_timer(tport_t *self, su_time_t now);
 int tport_bind_socket(int socket,
 		      su_addrinfo_t *ai,
 		      char const **return_culprit);
-#if defined(__linux__)
-int tport_bind_socket_iface(int s,
-		      su_sockaddr_t *su,
-		      su_addrinfo_t *ai);
+#if HAVE_GETIFADDRS && defined (__linux__)
+int tport_bind_socket_iface(int socket,
+		      su_addrinfo_t *ai,
+		      char const **return_culprit);
 #endif
 void tport_close(tport_t *self);
 int tport_shutdown0(tport_t *self, int how);

--- a/libsofia-sip-ua/tport/tport_tag.c
+++ b/libsofia-sip-ua/tport/tport_tag.c
@@ -247,6 +247,21 @@ tag_typedef_t tptag_pingpong = UINTTAG_TYPEDEF(pingpong);
  */
 tag_typedef_t tptag_pong2ping = BOOLTAG_TYPEDEF(pong2ping);
 
+#if defined (__linux__)
+/**@def TPTAG_SOCKET_BIND_IFC(x)
+ *
+ * Explicit socket binding to network interface (Linux only).
+ *
+ * If true, perform a setsockopt() SO_BINDTODEVICE.
+ *
+ * This is to get around an issue in certain Linux kernel whereas in a
+ * multi-homed environment, a socket might bind to the wrong (primary)
+ * network interface rather than the intended ifc.
+ *
+ */
+tag_typedef_t tptag_socket_bind_ifc = BOOLTAG_TYPEDEF(socket_bind_ifc);
+#endif
+
 /**@def TPTAG_SIGCOMP_LIFETIME(x)
  *
  * Default SigComp lifetime in seconds.


### PR DESCRIPTION
Address an issue seen in openWRT 22 (kernel 5.10) whereas the transport socket would not properly bind to an interface, almost at random, in a multi-homed system with a failover SIP profile. 
This caused the Sofia failover profile to bind to the primary interface, and thus the failover to still attempting to use the primary interface on a failover.
By forcing the socket to bind to the interface explicitly (SO_BINDTODEVICE), the proper interface binding is achieved.
Resolves #218 