### PR TITLE
[sofia-sip] fix issue 2283 by checking for SSL_ERROR_SSL and SSL_ERRO…

### DIFF
--- a/libsofia-sip-ua/tport/ws.h
+++ b/libsofia-sip-ua/tport/ws.h
@@ -78,7 +78,8 @@ typedef enum {
 	WS_NONE = 0,
 	WS_NORMAL = 1000,
 	WS_PROTO_ERR = 1002,
-	WS_DATA_TOO_BIG = 1009
+	WS_DATA_TOO_BIG = 1009,
+	WS_SSLERR = 1010
 } ws_cause_t;
 
 typedef enum {


### PR DESCRIPTION
…R_SYSCALL and avoiding socket i/o if so

Also adds various error checks to make sure we always operate on a valid socket and sets a 5 second timeout on the SSL_write call in ws_close() to avoid waiting forever on something that isn't talking to us. Plus a check before SSL_read when the connection is marked down. There is one stray printf debug message left in this commit that should probably be turned into something more freeswitchish to log it somewhere better.