### PR TITLE
Don't rely on libcrypto returning static buffers

### DIFF
--- a/libsofia-sip-ua/stun/stun_common.c
+++ b/libsofia-sip-ua/stun/stun_common.c
@@ -459,6 +459,7 @@ int stun_encode_message_integrity(stun_attr_t *attr,
 				  stun_buffer_t *pwd) {
   int padded_len;
   unsigned int dig_len;
+  unsigned char md[EVP_MAX_MD_SIZE];
   unsigned char *padded_text = NULL;
   void *sha1_hmac;
 
@@ -474,10 +475,10 @@ int stun_encode_message_integrity(stun_attr_t *attr,
     memcpy(padded_text, buf, len);
     memset(padded_text + len, 0, padded_len - len);
 
-    sha1_hmac = HMAC(EVP_sha1(), pwd->data, pwd->size, padded_text, padded_len, NULL, &dig_len);
+    sha1_hmac = HMAC(EVP_sha1(), pwd->data, pwd->size, padded_text, padded_len, md, &dig_len);
   }
   else {
-    sha1_hmac = HMAC(EVP_sha1(), pwd->data, pwd->size, buf, len, NULL, &dig_len);
+    sha1_hmac = HMAC(EVP_sha1(), pwd->data, pwd->size, buf, len, md, &dig_len);
   }
 
   assert(dig_len == 20);
@@ -525,6 +526,7 @@ int stun_validate_message_integrity(stun_msg_t *msg, stun_buffer_t *pwd)
   int padded_len, len;
   unsigned int dig_len;
   unsigned char dig[20]; /* received sha1 digest */
+  unsigned char md[EVP_MAX_MD_SIZE];
   unsigned char *padded_text;
 #endif
 
@@ -550,7 +552,7 @@ int stun_validate_message_integrity(stun_msg_t *msg, stun_buffer_t *pwd)
   memset(padded_text, 0, padded_len);
   memcpy(padded_text, msg->enc_buf.data, len);
 
-  memcpy(dig, HMAC(EVP_sha1(), pwd->data, pwd->size, padded_text, padded_len, NULL, &dig_len), 20);
+  memcpy(dig, HMAC(EVP_sha1(), pwd->data, pwd->size, padded_text, padded_len, md, &dig_len), 20);
 
   if (memcmp(dig, msg->enc_buf.data + msg->enc_buf.size - 20, 20) != 0) {
     /* does not match, but try the test server's password */


### PR DESCRIPTION
sofia-sip is one of very few applications relying on being able to pass NULL as last argument to the one-step hashing functions. BoringSSL has removed this functionality in 2017 [1] and LibreSSL 4.0 will do the same. Applications can pass in a correctly-sized buffer on the stack.

[1]: https://boringssl-review.googlesource.com/14528