### PR TITLE
New flag to always update the Route Set

### DIFF
--- a/libsofia-sip-ua/nta/nta.c
+++ b/libsofia-sip-ua/nta/nta.c
@@ -259,6 +259,8 @@ struct nta_agent_s
   unsigned sa_in_timer:1;	/**< Set when executing timers */
   unsigned sa_use_timer_c:1;	/**< Application has set value for timer C */
 
+  unsigned sa_always_update_route_set:1;	/**< Always update route set */
+
   unsigned :0;
 
 #if HAVE_SMIME
@@ -1502,6 +1504,7 @@ int agent_set_params(nta_agent_t *agent, tagi_t *tags)
   int use_naptr       = agent->sa_use_naptr;
   int use_srv         = agent->sa_use_srv;
   int srv_503         = agent->sa_srv_503;
+  int always_update_route_set = agent->sa_always_update_route_set;
   void *smime         = agent->sa_smime;
   uint32_t flags      = agent->sa_flags;
   int rport           = agent->sa_rport;
@@ -1569,6 +1572,7 @@ int agent_set_params(nta_agent_t *agent, tagi_t *tags)
 	      TPTAG_THRPSIZE_REF(threadpool),
 #endif
               NTATAG_SRV_503_REF(srv_503),
+	      NTATAG_ALWAYS_UPDATE_ROUTE_SET_REF(always_update_route_set),
 	      TAG_END());
   nC = tl_gets(tags,
 	       NTATAG_TIMER_C_REF(timer_c),
@@ -1733,6 +1737,7 @@ int agent_set_params(nta_agent_t *agent, tagi_t *tags)
   agent->sa_use_naptr = use_naptr != 0;
   agent->sa_use_srv = use_srv != 0;
   agent->sa_srv_503 = srv_503 != 0;
+  agent->sa_always_update_route_set = always_update_route_set != 0;
   agent->sa_smime = smime;
   agent->sa_flags = flags & MSG_FLG_USERMASK;
   agent->sa_rport = rport != 0;
@@ -4761,7 +4766,8 @@ int nta_leg_server_route(nta_leg_t *leg,
 			 sip_record_route_t const *route,
 			 sip_contact_t const *contact)
 {
-  return leg_route(leg, route, NULL, contact, 1);
+  int always_update_route_set = leg->leg_agent->sa_always_update_route_set;
+  return leg_route(leg, route, NULL, contact, always_update_route_set ? 2 : 1);
 }
 
 /** Return route components. */

--- a/libsofia-sip-ua/nta/nta_tag.c
+++ b/libsofia-sip-ua/nta/nta_tag.c
@@ -1547,6 +1547,20 @@ tag_typedef_t ntatag_srv_503 = BOOLTAG_TYPEDEF(srv_503);
 */
 tag_typedef_t ntatag_rseq = UINTTAG_TYPEDEF(rseq);
 
+/**@def NTATAG_ALWAYS_UPDATE_ROUTE_SET(x)
+ *
+ * If true, always update route set.
+ *
+ * @par Parameter type
+ *    boolean: true (non-zero or non-NULL pointer)
+ *          or false (zero or NULL pointer)
+ *
+ * @par Values
+ *    - true - enable always update route set
+ *    - false - disable always update route set
+ */
+tag_typedef_t ntatag_always_update_route_set = BOOLTAG_TYPEDEF(always_update_route_set);
+
 /* Status */
 
 /**@def NTATAG_S_IRQ_HASH_REF(x)

--- a/libsofia-sip-ua/nta/sofia-sip/nta_tag.h
+++ b/libsofia-sip-ua/nta/sofia-sip/nta_tag.h
@@ -417,6 +417,12 @@ NTA_DLL extern tag_typedef_t ntatag_rseq;
 NTA_DLL extern tag_typedef_t ntatag_rseq_ref;
 #define NTATAG_RSEQ_REF(x) ntatag_rseq_ref, tag_uint_vr(&(x))
 
+NTA_DLL extern tag_typedef_t ntatag_always_update_route_set;
+#define NTATAG_ALWAYS_UPDATE_ROUTE_SET(x) ntatag_always_update_route_set, tag_bool_v((x))
+
+NTA_DLL extern tag_typedef_t ntatag_always_update_route_set_ref;
+#define NTATAG_ALWAYS_UPDATE_ROUTE_SET_REF(x) ntatag_always_update_route_set_ref, tag_bool_vr(&(x))
+
 /* ====================================================================== */
 /* Tags for statistics. */
 


### PR DESCRIPTION
Right now, when there's a reINVITe in the middle of a call and the path for said INVITE changes, sofia-sip is not setup to update the route set for the call.

This causes that later on requests such as BYEs are sent through the original path eventually resulting in timeouts and weird behavior.

This flag gives us the ability to force these route set updates when receiving reINVITEs and should be used with caution as it goes against standard RFC3261 12.2

