### PR TITLE
fix MSG_STRING_E length issue

### DIFF
--- a/libsofia-sip-ua/msg/sofia-sip/msg_parser.h
+++ b/libsofia-sip-ua/msg/sofia-sip/msg_parser.h
@@ -224,7 +224,7 @@ SOFIAPUBFUN issize_t msg_parse_next_field(su_home_t *home, msg_header_t *prev,
 
 /** Encode a string. @HI */
 #define MSG_STRING_E(p, e, s) do { \
-  size_t _n = strlen(s); if (p + _n+1 < e) memcpy(p, s, _n+1); p+= _n; } while(0)
+  size_t _n = strlen(s); if (p + _n+1 <= e) memcpy(p, s, _n+1); p+= _n; } while(0)
 
 /** Duplicate string. @HI */
 #define MSG_STRING_DUP(p, d, s) \

--- a/libsofia-sip-ua/msg/test_msg.c
+++ b/libsofia-sip-ua/msg/test_msg.c
@@ -1174,6 +1174,16 @@ int test_copy(void)
   msg_destroy(msg1);
   msg_destroy(msg);
 
+  {
+    char dst[8];
+    const char *src = "1234567";
+
+    char *start = &dst;
+    char *end = start+sizeof(dst);
+    MSG_STRING_E(start, end, src);
+    TEST_S(dst, src);
+  }
+
   END();
 }
 


### PR DESCRIPTION
only need copy _n+1 bytes including the tail '\0', the memcpy should be performed when p+_n+1 equals e