### PR TITLE
Fix incompatible pointer type when building tests

### DIFF
--- a/libsofia-sip-ua/msg/test_msg.c
+++ b/libsofia-sip-ua/msg/test_msg.c
@@ -1178,7 +1178,7 @@ int test_copy(void)
     char dst[8];
     const char *src = "1234567";
 
-    char *start = &dst;
+    char *start = &dst[0];
     char *end = start+sizeof(dst);
     MSG_STRING_E(start, end, src);
     TEST_S(dst, src);


### PR DESCRIPTION
This is a corollary to #249 except for tests.