### PR TITLE
Build cleanly on GCC 14 / OpenSSL 3: fix all compiler warnings

### DIFF
--- a/libsofia-sip-ua/nua/nua_stack.c
+++ b/libsofia-sip-ua/nua/nua_stack.c
@@ -737,7 +737,7 @@ nua_event_data_t const *nua_event_data(nua_saved_event_t const saved[1])
  *
  * @sa #nua_event_e, nua_event_save(), nua_event_data(), nua_saved_event_request().
  */
-void nua_destroy_event(nua_saved_event_t saved[1])
+void nua_destroy_event(nua_saved_event_t *saved)
 {
   if (saved && saved[0]) su_msg_destroy(saved);
 }

--- a/libsofia-sip-ua/sip/sip_basic.c
+++ b/libsofia-sip-ua/sip/sip_basic.c
@@ -2853,7 +2853,7 @@ SIP_HEADER_CLASS(identity, "Identity", "", id_common, non_compact_append, identi
 issize_t sip_identity_d(su_home_t *home, sip_header_t *h, char *s, isize_t slen)
 {
   sip_identity_t *id = (sip_identity_t *)h;
-  char const *p = NULL, *pp = NULL, *ppp = NULL, *ie = NULL;
+  char *p = NULL, *pp = NULL, *ppp = NULL, *ie = NULL;
   char *sid = NULL, *uri = NULL, *alg = NULL, *ppt = NULL, *ext = NULL;
   size_t len = 0;
 

--- a/libsofia-sip-ua/stun/stun.c
+++ b/libsofia-sip-ua/stun/stun.c
@@ -1368,7 +1368,10 @@ int stun_tls_callback(su_root_magic_t *m, su_wait_t *w, su_wakeup_arg_t *arg)
     /* openssl initiation */
     SSLeay_add_ssl_algorithms();
     SSL_load_error_strings();
-    ctx = SSL_CTX_new(TLSv1_client_method());
+    /* TLSv1_client_method() was deprecated in OpenSSL 1.1.0; it pinned exactly
+     * TLS 1.0, so preserve that behavior with the version-flexible method plus a
+     * TLS 1.0-only protocol range. */
+    ctx = SSL_CTX_new(TLS_client_method());
     self->sh_ctx = ctx;
 
     if (ctx == NULL) {
@@ -1376,6 +1379,9 @@ int stun_tls_callback(su_root_magic_t *m, su_wait_t *w, su_wakeup_arg_t *arg)
       stun_free_buffer(&msg_req->enc_buf);
       return -1;
     }
+
+    SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
+    SSL_CTX_set_max_proto_version(ctx, TLS1_VERSION);
 
     if (SSL_CTX_set_cipher_list(ctx, "AES128-SHA") == 0) {
       STUN_ERROR(errno, SSL_CTX_set_cipher_list);

--- a/libsofia-sip-ua/su/sofia-sip/heap.h
+++ b/libsofia-sip-ua/su/sofia-sip/heap.h
@@ -109,8 +109,8 @@
  * @showinitializer
  */
 #define HEAP_DECLARE(scope, heaptype, prefix, type) \
-scope int prefix##resize(void *, heaptype *, size_t); \
-scope int prefix##free(void *, heaptype *); \
+scope int prefix##resize(void *, heaptype[1], size_t); \
+scope int prefix##free(void *, heaptype[1]); \
 scope int prefix##is_full(heaptype const); \
 scope size_t prefix##size(heaptype const); \
 scope size_t prefix##used(heaptype const); \

--- a/libsofia-sip-ua/su/sofia-sip/htable.h
+++ b/libsofia-sip-ua/su/sofia-sip/htable.h
@@ -127,7 +127,7 @@ HTABLE_SCOPE int prefix##_remove(prefix##_t *, entry_t const *e)
 /** Reallocate new hash table */ \
 HTABLE_SCOPE \
 int prefix##_resize(su_home_t *home, \
-                    prefix##_t pr[], \
+                    prefix##_t pr[1], \
 		    size_t new_size) \
 { \
   entry_t **new_hash; \

--- a/libsofia-sip-ua/su/su_alloc.c
+++ b/libsofia-sip-ua/su/su_alloc.c
@@ -1890,7 +1890,7 @@ void su_home_stats_free(su_block_t *sub, void *preload,
   hs->hs_blocks.hsb_rbytes -= rsize;
 }
 
-void su_home_stat_add(su_home_stat_t total[1], su_home_stat_t const hs[1])
+void su_home_stat_add(su_home_stat_t *total, su_home_stat_t const *hs)
 {
   total->hs_clones               += hs->hs_clones;
   total->hs_rehash               += hs->hs_rehash;

--- a/libsofia-sip-ua/su/su_localinfo.c
+++ b/libsofia-sip-ua/su/su_localinfo.c
@@ -1168,7 +1168,7 @@ err:
 #include <ifaddrs.h>
 
 static
-int bsd_localinfo(su_localinfo_t const hints[1],
+int bsd_localinfo(su_localinfo_t const *hints,
 		  su_localinfo_t **return_result)
 {
   struct ifaddrs *ifa, *results;

--- a/libsofia-sip-ua/tport/tport_tls.c
+++ b/libsofia-sip-ua/tport/tport_tls.c
@@ -155,7 +155,11 @@ void tls_log_errors(unsigned level, char const *s, unsigned long e)
   for (; e != 0; e = ERR_get_error()) {
     if (level <= tport_log->log_level) {
       const char *error = ERR_lib_error_string(e);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
       const char *func = ERR_func_error_string(e);
+#else
+      const char *func = "";	/* function name dropped from OpenSSL 3.0 error records */
+#endif
       const char *reason = ERR_reason_error_string(e);
 
       su_llog(tport_log, level, "%s: %08lx:%s:%s:%s\n",
@@ -392,6 +396,7 @@ SSL_CTX *tls_create_ctx(tls_issues_t const *ti)
   } else {
     BIO *bio = BIO_new_file(ti->key, "r");
     if (bio != NULL) {
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
       DH *dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
       if (dh != NULL) {
         if (!SSL_CTX_set_tmp_dh(ctx, dh)) {
@@ -406,6 +411,31 @@ SSL_CTX *tls_create_ctx(tls_issues_t const *ti)
         }
         DH_free(dh);
       }
+#else
+      /* OpenSSL 3.0 deprecated the DH API: read the parameters as a generic
+       * EVP_PKEY and install them with SSL_CTX_set0_tmp_dh_pkey(), which takes
+       * ownership on success (free only on failure). PEM_read_bio_Parameters()
+       * accepts any parameter type, so verify it really is DH before installing. */
+      EVP_PKEY *dh = PEM_read_bio_Parameters(bio, NULL);
+      if (dh != NULL) {
+        if (!EVP_PKEY_is_a(dh, "DH")) {
+          SU_DEBUG_1(("%s: %s does not contain DH parameters (PFS)\n",
+                      "tls_create_ctx", ti->key));
+          EVP_PKEY_free(dh);
+        } else if (!SSL_CTX_set0_tmp_dh_pkey(ctx, dh)) {
+          SU_DEBUG_1(("%s: invalid DH parameters (PFS) because %s: %s\n",
+                      "tls_create_ctx",
+                      ERR_reason_error_string(ERR_get_error()),
+                      ti->key));
+          EVP_PKEY_free(dh);	/* set0 failed: ownership stays with us */
+        } else {
+          long options = SSL_OP_CIPHER_SERVER_PREFERENCE | SSL_OP_SINGLE_DH_USE;
+          SSL_CTX_set_options(ctx, options);
+          SU_DEBUG_3(("%s\n", "tls: initialized DHE"));
+          /* set0 succeeded: the SSL_CTX now owns dh, do not free it */
+        }
+      }
+#endif
       BIO_free(bio);
     }
 #endif

--- a/libsofia-sip-ua/tport/tport_type_ws.c
+++ b/libsofia-sip-ua/tport/tport_type_ws.c
@@ -80,6 +80,7 @@ static int tport_ws_init_primary_secure(tport_primary_t *pri,
 
 static int tport_ws_setsndbuf(int socket, int atleast);
 static void tport_ws_deinit_primary(tport_primary_t *pri);
+static void tport_ws_deinit_secondary(tport_t *self);
 
 tport_vtable_t const tport_ws_vtable =
 {

--- a/libsofia-sip-ua/tport/tport_ws.h
+++ b/libsofia-sip-ua/tport/tport_ws.h
@@ -92,7 +92,6 @@ int tport_ws_init_secondary(tport_t *self, int socket, int accepted,
 
 int tport_ws_next_timer(tport_t *self, su_time_t *, char const **);
 void tport_ws_timer(tport_t *self, su_time_t);
-static void tport_ws_deinit_secondary(tport_t *self);
 
 SSL_CTX *tport_wss_create_ssl_ctx(char const *cert_dir);
 

--- a/libsofia-sip-ua/tport/ws.c
+++ b/libsofia-sip-ua/tport/ws.c
@@ -241,12 +241,7 @@ static void sha1_digest(char *digest, unsigned char *in)
 
 static void sha1_digest(unsigned char *digest, char *in)
 {
-	SHA_CTX sha;
-
-	SHA1_Init(&sha);
-	SHA1_Update(&sha, in, strlen(in));
-	SHA1_Final(digest, &sha);
-
+	EVP_Digest(in, strlen(in), digest, NULL, EVP_sha1(), NULL);
 }
 
 #endif
@@ -452,7 +447,11 @@ void wss_log_errors(unsigned level, char const *s, unsigned long e)
 	for (; e != 0; e = ERR_get_error()) {
 		if (level <= tport_log->log_level) {
 			const char *error = ERR_lib_error_string(e);
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 			const char *func = ERR_func_error_string(e);
+#else
+			const char *func = "";	/* function name dropped from OpenSSL 3.0 error records */
+#endif
 			const char *reason = ERR_reason_error_string(e);
 
 			su_llog(tport_log, level, "%s: %08lx:%s:%s:%s\n",

--- a/libsofia-sip-ua/tport/ws.h
+++ b/libsofia-sip-ua/tport/ws.h
@@ -27,6 +27,7 @@
 //#include "sha1.h"
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 
 #if defined(_MSC_VER) || defined(__APPLE__) || defined(__FreeBSD__) || (defined(__SVR4) && defined(__sun)) 
 #define __bswap_64(x) \


### PR DESCRIPTION
Building `master` on **GCC 14.2** against **OpenSSL 3.x** currently emits **25 warnings**. This fixes all of them so the library compiles with zero warnings / zero errors, with **no behavior or ABI change** (soname unchanged).

Closes #61, #81, #208. Related: #268, #326.

### Changes

- **`-Warray-parameter`** (new in GCC 14): align the prototype/definition spellings of the array-of-one / pointer parameters GCC now flags — the internal `HEAP_DECLARE` (heap.h) and `HTABLE` bodies (htable.h) macros, and `su_home_stat_add()`, `bsd_localinfo()`, `nua_destroy_event()`. An array-of-N parameter decays to a pointer, so the call ABI is unchanged; public prototypes are left untouched (the definitions are aligned to them).
- **`-Wdeprecated-declarations`** (OpenSSL 3.0):
  - `ws.c`: compute the WebSocket-handshake SHA-1 with the one-shot `EVP_Digest`/`EVP_sha1` instead of the deprecated `SHA1_Init`/`SHA1_Update`/`SHA1_Final`.
  - `ws.c`, `tport_tls.c`: the function name was dropped from OpenSSL 3.0 error records, so `ERR_func_error_string()` is kept below 3.0 and an empty function field is logged from 3.0 on (version-gated).
  - `tport_tls.c`: from OpenSSL 3.0, read the DH parameters as a generic `EVP_PKEY` and install them with `SSL_CTX_set0_tmp_dh_pkey()`, verifying the file really holds DH parameters (`EVP_PKEY_is_a("DH")`) and freeing the key only when ownership is not transferred; the pre-3.0 `PEM_read_bio_DHparams` / `SSL_CTX_set_tmp_dh` / `DH_free` path is unchanged.
  - `stun.c`: `TLSv1_client_method()` (deprecated in 1.1.0) pinned exactly TLS 1.0, so it is replaced with `TLS_client_method()` bounded to TLS 1.0 via the min and max protocol version, preserving the original behavior.
- **`-Wdiscarded-qualifiers`**: `sip_identity_d()` writes NUL terminators into its mutable `char *s`, so its scan pointers are plain `char *`.
- **`-Wunused-function`**: the private `tport_ws_deinit_secondary()` prototype is moved out of the shared `tport_ws.h` header into `tport_type_ws.c`, its only definition and use site.

Each change is behavior-preserving; verified by a full `make clean && make` on GCC 14.2 / OpenSSL 3.5.6 (0 warnings, 0 errors). Happy to split this into per-category commits if you'd prefer.
