### PR TITLE
sip_parser: fail closed if the message separator cannot be allocated

### DIFF
--- a/libsofia-sip-ua/sip/sip_parser.c
+++ b/libsofia-sip-ua/sip/sip_parser.c
@@ -668,8 +668,9 @@ int sip_complete_message(msg_t *msg)
   if (sip == NULL)
     return -1;
 
-  if (!sip->sip_separator)
-    sip->sip_separator = sip_separator_create(msg_home(msg));
+  if (!sip->sip_separator &&
+      !(sip->sip_separator = sip_separator_create(msg_home(msg))))
+    return -1;
 
   if (sip->sip_multipart) {
     sip_content_type_t *c = sip->sip_content_type;


### PR DESCRIPTION
`sip_complete_message()` created the trailing message separator with `sip_separator_create()` but never checked the result before the multipart path dereferences `sip->sip_separator->sep_common`. If the allocation fails the separator stays `NULL` and the message is dereferenced through a NULL pointer.

This returns `-1` — the function's existing error contract — when the separator cannot be allocated, fail-closed before any dereference. No behavior change on the success path; no ABI/API impact.

Fixes #312.
