### PR TITLE
nta/s2sip test: fix dead tcp/tls transport fallback (duplicated if condition)

### DIFF
--- a/s2check/s2sip.c
+++ b/s2check/s2sip.c
@@ -477,9 +477,9 @@ s2_sip_request_to(struct dialog *d,
 
   if (tport == NULL)
     tport = s2sip->udp.tport;
-  else if (tport == NULL)
+  if (tport == NULL)
     tport = s2sip->tcp.tport;
-  else if (tport == NULL)
+  if (tport == NULL)
     tport = s2sip->tls.tport;
 
   assert(tport);


### PR DESCRIPTION
The transport-selection fallback in `s2sip.c` used an `else if` chain that re-tests the same condition:

```c
if (tport == NULL)      tport = s2sip->udp.tport;
else if (tport == NULL) tport = s2sip->tcp.tport;
else if (tport == NULL) tport = s2sip->tls.tport;
```

Once the first `if` runs, the `else if` branches are unreachable (an `else` only runs when `tport` was non-NULL, and then re-checks `== NULL`, which is false), so the tcp/tls fallbacks were dead code. This switches to sequential `if` statements, matching the fallthrough style already used for the sut/tls selection a few lines above.

Fixes #99.
