### PR TITLE
nua: parse inbound multipart bodies into the request home, not the handle home

### DIFF
--- a/libsofia-sip-ua/nua/nua_session.c
+++ b/libsofia-sip-ua/nua/nua_session.c
@@ -2137,6 +2137,7 @@ nua_session_server_init(nua_server_request_t *sr)
   sip_t *sip = sr->sr_response.sip;
 
   sip_t *request = (sip_t *) sr->sr_request.sip;
+  su_home_t *request_home = msg_home(sr->sr_request.msg);
 
   if (!sr->sr_initial)
     sr->sr_usage = nua_dialog_usage_get(nh->nh_ds, nua_session_usage, NULL);
@@ -2167,7 +2168,7 @@ nua_session_server_init(nua_server_request_t *sr)
 		if (request->sip_multipart) {
 			mp = request->sip_multipart;
 		} else {
-			mp = msg_multipart_parse(nua_handle_home(nh),
+			mp = msg_multipart_parse(request_home,
 									 request->sip_content_type,
 									 (sip_payload_t *)request->sip_payload);
 			request->sip_multipart = mp;
@@ -2182,13 +2183,13 @@ nua_session_server_init(nua_server_request_t *sr)
 					mpp->mp_payload && mpp->mp_payload->pl_data && 
 					su_casenmatch(mpp->mp_content_type->c_type, "application/sdp", 15)) {
 
-					request->sip_content_type = msg_content_type_dup(nua_handle_home(nh), mpp->mp_content_type);
+					request->sip_content_type = msg_content_type_dup(request_home, mpp->mp_content_type);
 					
 					if (request->sip_content_length) {
 						request->sip_content_length->l_length = mpp->mp_payload->pl_len;
 					}
 					
-					request->sip_payload->pl_data = su_strdup(nua_handle_home(nh), mpp->mp_payload->pl_data);
+					request->sip_payload->pl_data = su_strdup(request_home, mpp->mp_payload->pl_data);
 					request->sip_payload->pl_len = mpp->mp_payload->pl_len;
 
 					sdp++;


### PR DESCRIPTION
`nua_session_server_init()` parsed an inbound `multipart/mixed` body with `msg_multipart_parse(nua_handle_home(nh), ...)` and duplicated the extracted `Content-Type` and SDP payload into `nua_handle_home(nh)` as well.

`msg_multipart_parse()` moves the parsed fragments into the supplied home (`su_home_move()`), so the parsed multipart lives until the **handle** is destroyed. Every multipart INVITE handled on a given handle therefore accumulates on the handle home — a leak for handles that process many requests (re-INVITEs, or INVITEs retried after a challenge). This matches the growth reported when flooding 407-rejected multipart INVITEs.

The parsed content is consumed immediately (the SDP offer is extracted into the request and handed to the offer/answer engine) and is not referenced past the request message. This allocates it in the **request message** home (`msg_home(sr->sr_request.msg)`) instead, so `request->sip_multipart`, `request->sip_content_type` and `request->sip_payload->pl_data` share the per-request lifetime and are released with the request. `sr->sr_request.msg` is set from `nta_incoming_getrequest()` and destroyed in `nua_server_request_destroy()`, so this is the correct per-request home. No ABI change.

Fixes #100.
