### PR TITLE
su_tagarg: fall back to the va_list copy path under AddressSanitizer

### DIFF
--- a/libsofia-sip-ua/su/sofia-sip/su_tagarg.h
+++ b/libsofia-sip-ua/su/sofia-sip/su_tagarg.h
@@ -102,7 +102,28 @@ typedef struct {
  *
  * @hideinitializer
  */
-#if SU_HAVE_TAGSTACK
+
+/* AddressSanitizer instruments the stack so the SU_HAVE_TAGSTACK fast path -
+ * which reads the variable arguments directly off the caller's stack via
+ * TAG_NEXT(&(v) + 1) - is walked below the ta stack object when the tag list is
+ * traversed (t_next -> t_next_next follows the raw stack pointer), which ASan
+ * correctly reports as a stack-buffer-underflow. Fall back to the portable
+ * va_list copy path (tl_vlist) under ASan. */
+#if defined(__SANITIZE_ADDRESS__)
+# define SU_TAGARG_ASAN 1
+#elif defined(__has_feature)
+# if __has_feature(address_sanitizer)
+#  define SU_TAGARG_ASAN 1
+# endif
+#endif
+
+#if SU_HAVE_TAGSTACK && !defined(SU_TAGARG_ASAN)
+# define SU_TAGARG_USE_TAGSTACK 1
+#else
+# define SU_TAGARG_USE_TAGSTACK 0
+#endif
+
+#if SU_TAGARG_USE_TAGSTACK
 /* All arguments are saved into stack (left-to-right) */
 #define ta_start(ta, t, v)						\
    do {									\
@@ -188,7 +209,7 @@ typedef struct {
  *
  * @hideinitializer
  */
-#if SU_HAVE_TAGSTACK
+#if SU_TAGARG_USE_TAGSTACK
 #define ta_end(ta) (va_end((ta).ap), (ta).tl->t_tag = NULL)
 #else
 #define ta_end(ta)					   \


### PR DESCRIPTION
The `SU_HAVE_TAGSTACK` fast path reads the variable arguments directly off the caller's stack — `ta_start()` stores `tl[1] = TAG_NEXT(&(v) + 1)`. When the resulting tag list is walked (e.g. `tl_len()` / `tl_adup()` following `t_next()` → `t_next_next()`), that raw stack pointer is dereferenced **below** the `ta` stack object, which AddressSanitizer correctly reports as a stack-buffer-underflow (the trace in this issue is via `nua_create()`).

The fix does **not** touch `TAG_TYPE_OF()`/`tl_len()`. It gates the stack fast path on a new `SU_TAGARG_USE_TAGSTACK = SU_HAVE_TAGSTACK && !AddressSanitizer` (GCC `__SANITIZE_ADDRESS__` / clang `__has_feature(address_sanitizer)`) and uses it for **both** `ta_start()` and `ta_end()`. Under ASan the existing portable `va_list` copy path (`tl_vlist` / `tl_vfree`) is taken instead, which never walks below the frame.

Normal builds are unchanged (`SU_TAGARG_USE_TAGSTACK == SU_HAVE_TAGSTACK`), and the `ta_list` layout (`tagi_t tl[2]`) is identical for both paths, so this is ABI-neutral. Verified: full build is warning-free, and a standalone preprocessor check prints `USE_TAGSTACK=1` for a normal GCC build and `USE_TAGSTACK=0` under `-fsanitize=address`.

Fixes #210.
