### PR TITLE
su_timer: skip an expired timer with no callback instead of aborting

### DIFF
--- a/libsofia-sip-ua/su/su_timer.c
+++ b/libsofia-sip-ua/su/su_timer.c
@@ -560,7 +560,17 @@ int su_timer_expire(su_timer_queue_t * const timers,
     timers_remove(timers[0], 1);
 
     f = t->sut_wakeup; t->sut_wakeup = NULL;
-    assert(f);
+    if (!f) {
+      /* A set timer reached expiry with no callback (a stale/racy entry, e.g.
+       * a concurrent su_timer_reset, or an invalidly-set timer). There is
+       * nothing valid to call, so mark it not-running and skip it rather than
+       * aborting the process (this was an assert(f)). */
+      SU_DEBUG_3(("su_timer_expire: timer %p expired with no callback, skipping\n",
+		  (void *)t));
+      t->sut_running = reset;
+      t->sut_arg = NULL;
+      continue;
+    }
 
     if (t->sut_running == run_at_intervals) {
       while (t->sut_running == run_at_intervals &&


### PR DESCRIPTION
`su_timer_expire()` asserted that a set, expired timer always has a wakeup callback. Under load a stale/racy or invalidly-set timer can reach expiry with a `NULL` callback (e.g. a concurrent `su_timer_reset()`); there is nothing valid to call, but `assert(f)` `abort()`s the whole process (#251, #255).

This skips such a timer gracefully: it is logged, marked not-running (`sut_running = reset`, `sut_arg = NULL`) and the loop continues with the next timer, rather than aborting. Timers that do have a callback are unaffected, and the skipped timer is not counted as fired.

Fixes #251, #255.
