### PR TITLE
stun: drop the redundant address copy after stun_atoaddr()

### DIFF
--- a/libsofia-sip-ua/stun/stun.c
+++ b/libsofia-sip-ua/stun/stun.c
@@ -1247,8 +1247,12 @@ int stun_test_nattype(stun_handle_t *sh,
     memmove(sd->sd_pri_addr, sh->sh_pri_addr, sizeof(su_sockaddr_t));
   }
   else {
+    /* stun_atoaddr() writes the resolved address through sd->sd_pri_info.ai_addr,
+     * which stun_discovery_create() aimed at sd->sd_pri_addr, so the server address
+     * is already in place here. The former copy took &sd->sd_pri_info.ai_addr - the
+     * address of the pointer field inside the addrinfo, overlapping sd_pri_addr and
+     * copying struct-tail bytes over the just-resolved address - so it is dropped. */
     err = stun_atoaddr(sh->sh_home, AF_INET, &sd->sd_pri_info, server);
-    memmove(sd->sd_pri_addr, &sd->sd_pri_info.ai_addr, sizeof(su_sockaddr_t));
   }
   destination = (su_sockaddr_t *) sd->sd_pri_addr;
 
@@ -2736,8 +2740,12 @@ int stun_test_lifetime(stun_handle_t *sh,
     memcpy(sd->sd_pri_addr, sh->sh_pri_addr, sizeof(su_sockaddr_t));
   }
   else {
+    /* stun_atoaddr() writes the resolved address through sd->sd_pri_info.ai_addr,
+     * which stun_discovery_create() aimed at sd->sd_pri_addr, so the server address
+     * is already in place here. The former copy took &sd->sd_pri_info.ai_addr - the
+     * address of the pointer field inside the addrinfo, overlapping sd_pri_addr and
+     * copying struct-tail bytes over the just-resolved address - so it is dropped. */
     err = stun_atoaddr(sh->sh_home, AF_INET, &sd->sd_pri_info, server);
-    memcpy(sd->sd_pri_addr, &sd->sd_pri_info.ai_addr, sizeof(su_sockaddr_t));
   }
   destination = (su_sockaddr_t *) sd->sd_pri_addr;
 


### PR DESCRIPTION
Fixes #335.

Both `stun_test_lifetime()` and `stun_get_nattype()`, on the branch where a server address is supplied, copied from `&sd->sd_pri_info.ai_addr` right after `stun_atoaddr()`. That is the address of the `ai_addr` pointer field inside the `su_addrinfo_t`, not the sockaddr it points to, so the copy overwrote the just-resolved server address in `sd_pri_addr` with addrinfo tail bytes (and overlapped, since `sd_pri_info` precedes `sd_pri_addr` in the struct).

The copy is also unnecessary: `stun_discovery_create()` sets `sd->sd_pri_info.ai_addr = &sd->sd_pri_addr->su_sa` (stun.c:1148) and `stun_atoaddr()` writes the resolved address through that pointer (stun.c:2623), so `sd_pri_addr` already holds the address when `stun_atoaddr()` returns.

This removes the redundant copy in both functions. The no-server branch's copy from `sh_pri_addr` (a different object) is a genuine copy and is left unchanged. GCC 14 at `-O2` also stops warning at the memcpy site (`-Wrestrict`, overlap).

No ABI or behavior change other than preserving the resolved address instead of clobbering it.